### PR TITLE
feat(mobile): Mobile support

### DIFF
--- a/packages/ord-connect/src/components/OrdConnectKit.tsx
+++ b/packages/ord-connect/src/components/OrdConnectKit.tsx
@@ -7,6 +7,7 @@ import { SelectWalletModal } from "./SelectWalletModal";
 export interface OrdConnectKitProp {
   customStyle?: string;
   onViewWallet?: () => void;
+  disableMobile?: boolean;
 }
 
 /**
@@ -21,6 +22,7 @@ export interface OrdConnectKitProp {
 export function OrdConnectKit({
   customStyle,
   onViewWallet,
+  disableMobile,
 }: OrdConnectKitProp) {
   const { address, network, isModalOpen, openModal, closeModal } =
     useOrdContext();
@@ -37,7 +39,11 @@ export function OrdConnectKit({
         <PreConnectButton openModal={openModal} customStyle={customStyle} />
       )}
 
-      <SelectWalletModal isOpen={isModalOpen} closeModal={closeModal} />
+      <SelectWalletModal
+        isOpen={isModalOpen}
+        closeModal={closeModal}
+        disableMobile={disableMobile}
+      />
     </>
   );
 }

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -8,6 +8,7 @@ interface WalletButtonProp {
   onConnect: () => Promise<boolean>;
   icon: string;
   setErrorMessage: (msg: string) => void;
+  isDisabled?: boolean;
 }
 
 export function WalletButton({
@@ -16,6 +17,7 @@ export function WalletButton({
   onConnect,
   icon,
   setErrorMessage,
+  isDisabled,
 }: WalletButtonProp) {
   const [loading, setLoading] = useState(false);
   return (
@@ -34,6 +36,7 @@ export function WalletButton({
           setLoading(false);
         }
       }}
+      disabled={isDisabled}
     >
       <img width={32} src={icon} alt={`Connect ${name} Wallet`} />
       <div className="wallet-option">

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -9,6 +9,7 @@ interface WalletButtonProp {
   icon: string;
   setErrorMessage: (msg: string) => void;
   isDisabled?: boolean;
+  isMobileDevice?: boolean;
 }
 
 export function WalletButton({
@@ -18,6 +19,7 @@ export function WalletButton({
   icon,
   setErrorMessage,
   isDisabled,
+  isMobileDevice,
 }: WalletButtonProp) {
   const [loading, setLoading] = useState(false);
   return (
@@ -41,7 +43,12 @@ export function WalletButton({
       <img width={32} src={icon} alt={`Connect ${name} Wallet`} />
       <div className="wallet-option">
         <span className="wallet-option-label">{name}</span>
-        <span className="wallet-option-info">{info}</span>
+        <span
+          className="wallet-option-info"
+          style={{ display: isMobileDevice ? "block" : "none" }}
+        >
+          {info}
+        </span>
       </div>
       {loading ? (
         <img

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -35,7 +35,7 @@ export function WalletButton({
         }
       }}
     >
-      <img width={40} src={icon} alt={`Connect ${name} Wallet`} />
+      <img width={32} src={icon} alt={`Connect ${name} Wallet`} />
       <div className="wallet-option">
         <span className="wallet-option-label">{name}</span>
         <span className="wallet-option-info">{info}</span>
@@ -43,13 +43,15 @@ export function WalletButton({
       {loading ? (
         <img
           src={LoadingIcon}
-          width={40}
+          width={30}
           alt={`${name} wallet extension is loading`}
         />
       ) : (
         <img
           src={ChevronRightIcon}
           alt="Chevron Right"
+          width={20}
+          height={20}
           className="chveron-btn"
         />
       )}

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -4,6 +4,7 @@ import LoadingIcon from "../../assets/loading.svg";
 
 interface WalletButtonProp {
   name: string;
+  info: string;
   onConnect: () => Promise<boolean>;
   icon: string;
   setErrorMessage: (msg: string) => void;
@@ -11,6 +12,7 @@ interface WalletButtonProp {
 
 export function WalletButton({
   name,
+  info,
   onConnect,
   icon,
   setErrorMessage,
@@ -34,7 +36,10 @@ export function WalletButton({
       }}
     >
       <img width={40} src={icon} alt={`Connect ${name} Wallet`} />
-      <span className="wallet-option-label">{name}</span>
+      <div className="wallet-option">
+        <span className="wallet-option-label">{name}</span>
+        <span className="wallet-option-info">{info}</span>
+      </div>
       {loading ? (
         <img
           src={LoadingIcon}
@@ -42,7 +47,11 @@ export function WalletButton({
           alt={`${name} wallet extension is loading`}
         />
       ) : (
-        <img src={ChevronRightIcon} alt="Chevron Right" />
+        <img
+          src={ChevronRightIcon}
+          alt="Chevron Right"
+          className="chveron-btn"
+        />
       )}
     </button>
   );

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -40,31 +40,37 @@ export function WalletButton({
       }}
       disabled={isDisabled}
     >
-      <img width={32} src={icon} alt={`Connect ${name} Wallet`} />
-      <div className="wallet-option">
-        <span className="wallet-option-label">{name}</span>
-        <span
-          className="wallet-option-info"
-          style={{ display: isMobileDevice ? "block" : "none" }}
-        >
-          {info}
-        </span>
+      <div className="option-wrapper">
+        <img
+          className="wallet-icon"
+          src={icon}
+          alt={`Connect ${name} Wallet`}
+        />
+        <div className="wallet-option">
+          <span className="wallet-option-label">{name}</span>
+          <span
+            className="wallet-option-info"
+            style={{ display: isMobileDevice ? "block" : "none" }}
+          >
+            {info}
+          </span>
+        </div>
+        {loading ? (
+          <img
+            src={LoadingIcon}
+            width={30}
+            alt={`${name} wallet extension is loading`}
+          />
+        ) : (
+          <img
+            src={ChevronRightIcon}
+            alt="Chevron Right"
+            width={20}
+            height={20}
+            className="chveron-btn"
+          />
+        )}
       </div>
-      {loading ? (
-        <img
-          src={LoadingIcon}
-          width={30}
-          alt={`${name} wallet extension is loading`}
-        />
-      ) : (
-        <img
-          src={ChevronRightIcon}
-          alt="Chevron Right"
-          width={20}
-          height={20}
-          className="chveron-btn"
-        />
-      )}
     </button>
   );
 }

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -197,7 +197,7 @@ export function SelectWalletModal({
                         onConnect={onConnectUnisatWallet}
                         icon={UnisatWalletIcon}
                         setErrorMessage={setErrorMessage}
-                        isDisabled={isMobileDevice()}
+                        isDisabled={isMobileDevice()} // disable unisat on mobile until it is supported
                         isMobileDevice={isMobileDevice()}
                       />
                       <hr className="horizontal-separator" />

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -10,15 +10,18 @@ import {
   XVERSE_WALLET_CHROME_EXTENSION_URL,
 } from "../../utils/constant";
 import { WalletButton } from "./WalletButton";
+import { isMobileDevice } from "../../utils/mobile-detector.ts";
 
 interface SelectWalletModalProp {
   isOpen: boolean;
   closeModal: () => void;
+  disableMobile?: boolean;
 }
 
 export function SelectWalletModal({
   isOpen,
   closeModal,
+  disableMobile,
 }: SelectWalletModalProp) {
   const {
     updateAddress,
@@ -32,7 +35,7 @@ export function SelectWalletModal({
     publicKey,
   } = useOrdContext();
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const isChromium = window.chrome;
+  const supportedDevice = !disableMobile || !isMobileDevice();
 
   const onConnectUnisatWallet = async () => {
     try {
@@ -172,9 +175,9 @@ export function SelectWalletModal({
               <Dialog.Panel className="panel">
                 <section className="panel-title-container">
                   <Dialog.Title as="h3" className="panel-title">
-                    {isChromium
+                    {supportedDevice
                       ? "Choose wallet to connect"
-                      : "Unsupported Browser"}
+                      : "Unsupported device"}
                   </Dialog.Title>
                   <button
                     type="button"
@@ -186,7 +189,7 @@ export function SelectWalletModal({
                 </section>
 
                 <section className="panel-content-container">
-                  {isChromium ? (
+                  {supportedDevice ? (
                     <section className="panel-content-inner-container">
                       <WalletButton
                         name="Unisat"
@@ -204,8 +207,7 @@ export function SelectWalletModal({
                     </section>
                   ) : (
                     <Dialog.Description className="unsupported-browser-message">
-                      To connect to your wallet, please download Google Chrome
-                      or any other Chromium-based browser.
+                      This website does not support mobile devices.
                     </Dialog.Description>
                   )}
                   <p className="error-message">{errorMessage}</p>

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -193,6 +193,7 @@ export function SelectWalletModal({
                     <section className="panel-content-inner-container">
                       <WalletButton
                         name="Unisat"
+                        info="Coming soon on mobile browsing"
                         onConnect={onConnectUnisatWallet}
                         icon={UnisatWalletIcon}
                         setErrorMessage={setErrorMessage}
@@ -200,6 +201,7 @@ export function SelectWalletModal({
                       <hr className="horizontal-separator" />
                       <WalletButton
                         name="Xverse"
+                        info="Available on Xverse app"
                         onConnect={onConnectXverseWallet}
                         icon={XverseWalletIcon}
                         setErrorMessage={setErrorMessage}

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -35,7 +35,7 @@ export function SelectWalletModal({
     publicKey,
   } = useOrdContext();
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const supportedDevice = !disableMobile || !isMobileDevice();
+  const isSupportedDevice = !disableMobile || !isMobileDevice();
 
   const onConnectUnisatWallet = async () => {
     try {
@@ -175,7 +175,7 @@ export function SelectWalletModal({
               <Dialog.Panel className="panel">
                 <section className="panel-title-container">
                   <Dialog.Title as="h3" className="panel-title">
-                    {supportedDevice
+                    {isSupportedDevice
                       ? "Choose wallet to connect"
                       : "Unsupported device"}
                   </Dialog.Title>
@@ -189,7 +189,7 @@ export function SelectWalletModal({
                 </section>
 
                 <section className="panel-content-container">
-                  {supportedDevice ? (
+                  {isSupportedDevice ? (
                     <section className="panel-content-inner-container">
                       <WalletButton
                         name="Unisat"

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -192,7 +192,7 @@ export function SelectWalletModal({
                   {isSupportedDevice ? (
                     <section className="panel-content-inner-container">
                       <WalletButton
-                        name="Unisat"
+                        name="Unisat Wallet"
                         info="Coming soon on mobile browsing"
                         onConnect={onConnectUnisatWallet}
                         icon={UnisatWalletIcon}

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -198,6 +198,7 @@ export function SelectWalletModal({
                         icon={UnisatWalletIcon}
                         setErrorMessage={setErrorMessage}
                         isDisabled={isMobileDevice()}
+                        isMobileDevice={isMobileDevice()}
                       />
                       <hr className="horizontal-separator" />
                       <WalletButton
@@ -206,6 +207,7 @@ export function SelectWalletModal({
                         onConnect={onConnectXverseWallet}
                         icon={XverseWalletIcon}
                         setErrorMessage={setErrorMessage}
+                        isMobileDevice={isMobileDevice()}
                       />
                     </section>
                   ) : (

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -197,6 +197,7 @@ export function SelectWalletModal({
                         onConnect={onConnectUnisatWallet}
                         icon={UnisatWalletIcon}
                         setErrorMessage={setErrorMessage}
+                        isDisabled={isMobileDevice()}
                       />
                       <hr className="horizontal-separator" />
                       <WalletButton

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -58,7 +58,6 @@
   justify-content: space-between;
   padding: 32px 24px 20px;
   align-items: center;
-  border-bottom: 1px solid #333;
 }
 
 @media screen and (min-width: 768px) {
@@ -75,12 +74,20 @@
 }
 
 .ord-connect-wallet-modal .panel-title {
-  font-weight: 600;
-  font-size: 20px;
-  line-height: 28px;
-  letter-spacing: 1%;
-  color: #fff;
-  margin: 0px;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 32px;
+}
+
+@media screen and (min-width: 768px) {
+  .ord-connect-wallet-modal .panel-title {
+    font-size: 20px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 28px;
+    letter-spacing: 0.2px;
+  }
 }
 
 .ord-connect-wallet-modal .unsupported-browser-message {

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -152,23 +152,42 @@
 }
 
 .ord-connect-wallet-modal .wallet-option-button:first-child {
-  padding: 32px 32px 24px;
+  padding: 24px 24px 16px;
   border: 0px;
   margin-bottom: 0px;
-  border-radius: 20px 20px 20px 20px;
+  border-radius: 20px 20px 0px 0px;
 }
 
 .ord-connect-wallet-modal .wallet-option-button:nth-of-type(2) {
   border: 0px;
-  padding: 24px 32px 32px;
+  padding: 16px 24px 24px;
   margin-bottom: 0px;
   border-radius: 0px 0px 20px 20px;
 }
 
-.ord-connect-wallet-modal .wallet-option-label {
-  margin-left: 16px;
+.ord-connect-wallet-modal .wallet-option {
   flex-grow: 1;
+  margin-left: 16px;
   text-align: left;
+}
+.ord-connect-wallet-modal .wallet-option-label {
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 24px;
+}
+
+.ord-connect-wallet-modal .wallet-option-info {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+  color: #8c8c8c;
+}
+
+@media (min-width: 768px) {
+  .ord-connect-wallet-modal .wallet-option-info {
+    display: none;
+  }
 }
 
 .ord-connect-wallet-modal .horizontal-separator {
@@ -182,4 +201,13 @@
   color: #e54545;
   font-size: 14px;
   line-height: 20px;
+}
+
+.chveron-btn {
+  transition: opacity 0.3s ease-in-out;
+  opacity: 0.3;
+}
+
+.chveron-btn:hover {
+  opacity: 1;
 }

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -87,6 +87,7 @@
 }
 
 .ord-connect-wallet-modal .close-button {
+  display: inline-flex;
   background: transparent;
   border: 0px;
   cursor: pointer;

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -24,7 +24,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 628px;
+    width: 500px;
     height: auto;
     border-radius: 20px;
   }
@@ -75,9 +75,10 @@
 }
 
 .ord-connect-wallet-modal .panel-title {
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 32px;
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 28px;
+  letter-spacing: 1%;
   color: #fff;
   margin: 0px;
 }
@@ -147,6 +148,24 @@
   object-fit: cover;
 }
 
+.ord-connect-wallet-modal .option-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 12px;
+  width: 100%;
+}
+
+@media screen and (min-width: 1080px) {
+  .ord-connect-wallet-modal .option-wrapper {
+    padding: 16px;
+  }
+}
+
+.ord-connect-wallet-modal .wallet-option-button {
+  padding: 8px 16px;
+}
+
 .ord-connect-wallet-modal .wallet-option-button:hover {
   background: rgba(255, 255, 255, 0.1);
 }
@@ -157,7 +176,7 @@
 }
 
 .ord-connect-wallet-modal .wallet-option-button:first-child {
-  padding: 24px 24px 16px;
+  padding: 16px 16px 8px 16px;
   border: 0px;
   margin-bottom: 0px;
   border-radius: 20px 20px 0px 0px;
@@ -165,9 +184,22 @@
 
 .ord-connect-wallet-modal .wallet-option-button:nth-of-type(2) {
   border: 0px;
-  padding: 16px 24px 24px;
   margin-bottom: 0px;
   border-radius: 0px 0px 20px 20px;
+}
+
+.ord-connect-wallet-modal .wallet-option-button:last-child {
+  padding: 8px 16px 16px 16px;
+}
+
+.ord-connect-wallet-modal .wallet-icon {
+  width: 32px;
+}
+
+@media (min-width: 768px) {
+  .ord-connect-wallet-modal .wallet-icon {
+    width: 40px;
+  }
 }
 
 .ord-connect-wallet-modal .wallet-option {
@@ -179,6 +211,14 @@
   font-size: 16px;
   font-weight: 600;
   line-height: 20px;
+}
+
+@media screen and (min-width: 1079px) {
+  .ord-connect-wallet-modal .wallet-option-label {
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 24px;
+  }
 }
 
 .ord-connect-wallet-modal .wallet-option-info {

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -142,13 +142,17 @@
   object-fit: cover;
 }
 
-.ord-connect-wallet-modal .wallet-option-button:hover {
-  background: rgba(255, 255, 255, 0.1);
+.ord-connect-wallet-modal .wallet-option-button {
+  opacity: 1;
+  transition: opacity 0.3s;
 }
 
-.ord-connect-wallet-modal .wallet-option-button:active {
-  background: rgba(255, 255, 255, 0.1);
-  opacity: 0.7;
+.panel-content-inner-container:hover .wallet-option-button {
+  opacity: 0.35;
+}
+
+.ord-connect-wallet-modal .wallet-option-button:hover {
+  opacity: 1;
 }
 
 .ord-connect-wallet-modal .wallet-option-button:first-child {

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -182,17 +182,10 @@
 }
 
 .ord-connect-wallet-modal .wallet-option-info {
-  display: block;
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
   color: #8c8c8c;
-}
-
-@media (min-width: 768px) {
-  .ord-connect-wallet-modal .wallet-option-info {
-    display: none;
-  }
 }
 
 .ord-connect-wallet-modal .horizontal-separator {

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -206,12 +206,3 @@
   font-size: 14px;
   line-height: 20px;
 }
-
-.chveron-btn {
-  transition: opacity 0.3s ease-in-out;
-  opacity: 0.3;
-}
-
-.chveron-btn:hover {
-  opacity: 1;
-}

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -171,9 +171,9 @@
   text-align: left;
 }
 .ord-connect-wallet-modal .wallet-option-label {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
-  line-height: 24px;
+  line-height: 20px;
 }
 
 .ord-connect-wallet-modal .wallet-option-info {

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -56,15 +56,14 @@
 .ord-connect-wallet-modal .panel-title-container {
   display: flex;
   justify-content: space-between;
-  padding: 32px 24px 20px;
+  padding: 32px 24px 0px 24px;
   align-items: center;
 }
 
 @media screen and (min-width: 768px) {
   .ord-connect-wallet-modal .panel-title-container {
-    padding-left: 48px;
+    padding: 24px 32px 0px 32px;
     border-bottom: 0px;
-    padding-bottom: 8px;
   }
 
   .ord-connect-wallet-modal .unsupported-browser-message {
@@ -78,6 +77,7 @@
   font-style: normal;
   font-weight: 700;
   line-height: 32px;
+  margin: 0px;
 }
 
 @media screen and (min-width: 768px) {
@@ -102,13 +102,18 @@
 }
 
 .ord-connect-wallet-modal .panel-content-container {
-  margin: 64px 24px 0px;
+  margin: 32px 24px 0px;
 }
 
 @media screen and (min-width: 768px) {
   .ord-connect-wallet-modal .panel-content-container {
-    margin-bottom: 48px;
-    margin-top: 48px;
+    margin: 48px 32px 32px 32px;
+  }
+}
+
+@media screen and (min-width: 1080px) {
+  .ord-connect-wallet-modal .panel-content-container {
+    margin: 48px 32px 32px 32px;
   }
 }
 

--- a/packages/ord-connect/src/components/SelectWalletModal/style.css
+++ b/packages/ord-connect/src/components/SelectWalletModal/style.css
@@ -124,6 +124,10 @@
   cursor: pointer;
 }
 
+.ord-connect-wallet-modal .wallet-option-button:disabled .chveron-btn {
+  opacity: 0.3;
+}
+
 .waiting-cursor {
   cursor: wait !important;
 }
@@ -143,17 +147,13 @@
   object-fit: cover;
 }
 
-.ord-connect-wallet-modal .wallet-option-button {
-  opacity: 1;
-  transition: opacity 0.3s;
-}
-
-.panel-content-inner-container:hover .wallet-option-button {
-  opacity: 0.35;
-}
-
 .ord-connect-wallet-modal .wallet-option-button:hover {
-  opacity: 1;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.ord-connect-wallet-modal .wallet-option-button:active {
+  background: rgba(255, 255, 255, 0.1);
+  opacity: 0.7;
 }
 
 .ord-connect-wallet-modal .wallet-option-button:first-child {

--- a/packages/ord-connect/src/main.tsx
+++ b/packages/ord-connect/src/main.tsx
@@ -69,7 +69,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <OrdConnectProvider initialNetwork="testnet" initialSafeMode>
       <SampleComponent />
-      <OrdConnectKit />
+      <OrdConnectKit disableMobile={false} />
     </OrdConnectProvider>
   </React.StrictMode>,
 );

--- a/packages/ord-connect/src/utils/constant.ts
+++ b/packages/ord-connect/src/utils/constant.ts
@@ -1,5 +1,4 @@
-// Both Unisat and Xverse only support Chrome
 export const UNISAT_WALLET_CHROME_EXTENSION_URL =
-  "https://chrome.google.com/webstore/detail/unisat-wallet/ppbibelpcjmhbdihakflkdcoccbgbkpo";
+  "https://www.unisat.io/download";
 export const XVERSE_WALLET_CHROME_EXTENSION_URL =
-  "https://chrome.google.com/webstore/detail/xverse-wallet/idnnbdplmphpflfnlkomgpfbpcgelopg";
+  "https://www.xverse.app/download";

--- a/packages/ord-connect/src/utils/constant.ts
+++ b/packages/ord-connect/src/utils/constant.ts
@@ -1,4 +1,4 @@
-export const UNISAT_WALLET_CHROME_EXTENSION_URL =
-  "https://www.unisat.io/download";
+// their www subdomain doesn't work lol
+export const UNISAT_WALLET_CHROME_EXTENSION_URL = "https://unisat.io/download";
 export const XVERSE_WALLET_CHROME_EXTENSION_URL =
   "https://www.xverse.app/download";

--- a/packages/ord-connect/src/utils/mobile-detector.ts
+++ b/packages/ord-connect/src/utils/mobile-detector.ts
@@ -1,0 +1,5 @@
+export function isMobileDevice() {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent,
+  );
+}


### PR DESCRIPTION
(Optionally) removes presumptuousness. Redirect users to UniSat / Xverse official website if the extension is not detected. Don't gate-keep browsers.

`disableMobile` flag added to `<OrdConnectKit />` to prevent mobile users from connecting their wallet, if necessary.

sub-task: ORD-821