### PR TITLE
fix(select-wallet): fix error message handling

### DIFF
--- a/packages/ord-connect/package.json
+++ b/packages/ord-connect/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
-    "@ordzaar/ordit-sdk": "1.0.4",
+    "@ordzaar/ordit-sdk": "1.0.5",
     "bitcoinjs-lib": "6.1.5",
     "boring-avatars": "^1.10.1"
   },
@@ -60,7 +60,7 @@
     ]
   },
   "peerDependencies": {
-    "@ordzaar/ordit-sdk": "1.0.4",
+    "@ordzaar/ordit-sdk": "1.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -3,6 +3,7 @@ import { Dialog, Transition } from "@headlessui/react";
 import {
   AddressFormat,
   BrowserWalletNotInstalledError,
+  BrowserWalletRequestCancelledByUserError,
 } from "@ordzaar/ordit-sdk";
 import { getAddresses as getUnisatAddresses } from "@ordzaar/ordit-sdk/unisat";
 import { getAddresses as getXverseAddresses } from "@ordzaar/ordit-sdk/xverse";
@@ -45,22 +46,26 @@ export function SelectWalletModal({
   const [errorMessage, setErrorMessage] = useState<string>("");
   const isSupportedDevice = !disableMobile || !isMobileDevice();
 
-  const onError = useCallback((walletProvider: Wallet, err: unknown) => {
-    if (err instanceof BrowserWalletNotInstalledError) {
-      window.open(
-        WALLET_CHROME_EXTENSION_URL[walletProvider],
-        "_blank",
-        "noopener,noreferrer",
-      );
-    }
-    if (err instanceof Error) {
+  const onError = useCallback(
+    (
+      walletProvider: Wallet,
+      err:
+        | BrowserWalletNotInstalledError
+        | BrowserWalletRequestCancelledByUserError
+        | Error,
+    ) => {
+      if (err instanceof BrowserWalletNotInstalledError) {
+        window.open(
+          WALLET_CHROME_EXTENSION_URL[walletProvider],
+          "_blank",
+          "noopener,noreferrer",
+        );
+      }
       setErrorMessage(err.message ?? err.toString());
-    } else {
-      // safeguard as we don't throw string errors
-      setErrorMessage("Unknown error occurred.");
-    }
-    console.error(`Error while connecting to ${walletProvider} wallet`, err);
-  }, []);
+      console.error(`Error while connecting to ${walletProvider} wallet`, err);
+    },
+    [],
+  );
 
   const onConnectUnisatWallet = async (readOnly?: boolean) => {
     try {
@@ -100,7 +105,7 @@ export function SelectWalletModal({
       );
       closeModal();
       return true;
-    } catch (err: unknown) {
+    } catch (err) {
       onError(Wallet.UNISAT, err);
       return false;
     }
@@ -137,7 +142,7 @@ export function SelectWalletModal({
       });
       closeModal();
       return true;
-    } catch (err: unknown) {
+    } catch (err) {
       onError(Wallet.XVERSE, err);
       return false;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.7.17
         version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@ordzaar/ordit-sdk':
-        specifier: 1.0.4
-        version: 1.0.4
+        specifier: 1.0.5
+        version: 1.0.5
       bitcoinjs-lib:
         specifier: 6.1.5
         version: 6.1.5
@@ -581,8 +581,8 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@ordzaar/ordit-sdk@1.0.4:
-    resolution: {integrity: sha512-HZodFs6V9hfe67ry+V3bZIEdmFH4XH/PJ1IF3RGBR71vLke2zw1R8XUV9mWcg7Y6fIpG/Zs6ryKsV5Tp8dNp/w==}
+  /@ordzaar/ordit-sdk@1.0.5:
+    resolution: {integrity: sha512-WUFHBRNEoLPXmPogyfqJtc2tH+VpvuixK+XwaaA3+tjQxiwbAfsHcLX0T+ZuQR4qkhNtpojca97qXKUwjW4miw==}
     dependencies:
       '@bitcoinerlab/secp256k1': 1.0.5
       bignumber.js: 9.1.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

The error message previously naively assumes that all errors are of the Error prototype. Anyway this case is covered by `error.toString()`, so we don't have to show an unknown error message.

The updated ordit-sdk 1.0.5 will also have all errors with the Error type since it's wrapped now.

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
