### PR TITLE
fix(local-storage): disconnect wallet properly

### DIFF
--- a/packages/ord-connect/.eslintrc.cjs
+++ b/packages/ord-connect/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
     "import/prefer-default-export": "off",
     "@typescript-eslint/no-explicit-any": "warn",
     "jsx-a11y/control-has-associated-label": "warn",
+    "@next/next/no-img-element": "off",
   },
   overrides: [
     {

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -30,7 +30,12 @@ export function WalletButton({
       onClick={async () => {
         setLoading(true);
         const timeout = (resolve) => setTimeout(() => resolve("timeout"), 5000);
-        const success = await Promise.race([onConnect(), new Promise(timeout)]);
+        const success = await Promise.race([
+          onConnect()
+            .then(() => setLoading(false))
+            .catch(() => setLoading(false)),
+          new Promise(timeout),
+        ]);
         if (success === "timeout") {
           setErrorMessage(
             "No wallet pop-up? The extension is not responding. Try reloading your browser.",

--- a/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/WalletButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import ChevronRightIcon from "../../assets/chevron-right.svg";
 import LoadingIcon from "../../assets/loading.svg";
@@ -23,27 +23,31 @@ export function WalletButton({
   isMobileDevice,
 }: WalletButtonProp) {
   const [loading, setLoading] = useState(false);
+
+  const handleWalletConnectClick = useCallback(async () => {
+    setLoading(true);
+    const result = await Promise.race([
+      onConnect()
+        .then(() => setLoading(false))
+        .catch(() => setLoading(false)),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("timeout"), 5000);
+      }),
+    ]);
+    if (result === "timeout") {
+      setErrorMessage(
+        "No wallet pop-up? The extension is not responding. Try reloading your browser.",
+      );
+    } else {
+      setLoading(false);
+    }
+  }, [onConnect, setErrorMessage]);
+
   return (
     <button
       type="button"
       className="wallet-option-button"
-      onClick={async () => {
-        setLoading(true);
-        const timeout = (resolve) => setTimeout(() => resolve("timeout"), 5000);
-        const success = await Promise.race([
-          onConnect()
-            .then(() => setLoading(false))
-            .catch(() => setLoading(false)),
-          new Promise(timeout),
-        ]);
-        if (success === "timeout") {
-          setErrorMessage(
-            "No wallet pop-up? The extension is not responding. Try reloading your browser.",
-          );
-        } else {
-          setLoading(false);
-        }
-      }}
+      onClick={handleWalletConnectClick}
       disabled={isDisabled}
     >
       <div className="option-wrapper">

--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import {
-  AddressFormat,
   BrowserWalletNotInstalledError,
   BrowserWalletRequestCancelledByUserError,
 } from "@ordzaar/ordit-sdk";
@@ -96,8 +95,8 @@ export function SelectWalletModal({
       });
       updateWallet(Wallet.UNISAT);
       updateFormat({
-        ordinals: unisatWallet.format as AddressFormat,
-        payments: unisatWallet.format as AddressFormat,
+        ordinals: unisatWallet.format,
+        payments: unisatWallet.format,
       });
 
       window.unisat.addListener("accountsChanged", () =>
@@ -137,8 +136,8 @@ export function SelectWalletModal({
       });
       updateWallet(Wallet.XVERSE);
       updateFormat({
-        ordinals: taproot.format as AddressFormat,
-        payments: p2sh.format as AddressFormat,
+        ordinals: taproot.format,
+        payments: p2sh.format,
       });
       closeModal();
       return true;

--- a/packages/ord-connect/src/hooks/useLocalStorage.ts
+++ b/packages/ord-connect/src/hooks/useLocalStorage.ts
@@ -1,10 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
 
 const KEY_PREFIX = "ord-connect";
 
@@ -37,9 +31,13 @@ export function useLocalStorage<T>(
   key: string,
   initialValue: T,
 ): [T, Dispatch<SetStateAction<T>>] {
-  const [state, setInnerState] = useState<T>(
-    () => getItemFromLocalStorage(key) ?? initialValue,
-  );
+  const [state, setInnerState] = useState<T>(() => {
+    const value = getItemFromLocalStorage<T>(key);
+    if (!value) {
+      setItemToLocalStorage(key, initialValue);
+    }
+    return value;
+  });
 
   const setState = useCallback(
     (newValue: T) => {
@@ -48,10 +46,6 @@ export function useLocalStorage<T>(
     },
     [key],
   );
-
-  useEffect(() => {
-    setState(initialValue);
-  }, [initialValue, setState]);
 
   return [state, setState];
 }

--- a/packages/ord-connect/src/hooks/useLocalStorage.ts
+++ b/packages/ord-connect/src/hooks/useLocalStorage.ts
@@ -1,0 +1,57 @@
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+
+const KEY_PREFIX = "ord-connect";
+
+// Helper function to get item from localStorage
+function getItemFromLocalStorage<T>(_key: string): T | null {
+  const key = `${KEY_PREFIX}_${_key}`;
+  try {
+    return JSON.parse(localStorage.getItem(key)) as T | null;
+  } catch (error) {
+    console.error(`Error retrieving ${key} from localStorage`, error);
+    return null;
+  }
+}
+
+// Helper function to set item to localStorage
+function setItemToLocalStorage<T>(_key: string, value: T) {
+  const key = `${KEY_PREFIX}_${_key}`;
+  try {
+    if (value) {
+      localStorage.setItem(key, JSON.stringify(value));
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch (error) {
+    console.error(`Error saving ${key} to localStorage`, error);
+  }
+}
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setInnerState] = useState<T>(
+    () => getItemFromLocalStorage(key) ?? initialValue,
+  );
+
+  const setState = useCallback(
+    (newValue: T) => {
+      setItemToLocalStorage(key, newValue);
+      setInnerState(newValue);
+    },
+    [key],
+  );
+
+  useEffect(() => {
+    setState(initialValue);
+  }, [initialValue, setState]);
+
+  return [state, setState];
+}

--- a/packages/ord-connect/src/providers/OrdContext.tsx
+++ b/packages/ord-connect/src/providers/OrdContext.tsx
@@ -132,6 +132,8 @@ export function OrdConnectProvider({
   );
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const openModal = useCallback(() => setIsModalOpen(true), []);
+  const closeModal = useCallback(() => setIsModalOpen(false), []);
 
   const disconnectWallet = useCallback(() => {
     setAddress(EMPTY_BIADDRESS_OBJECT);
@@ -151,25 +153,27 @@ export function OrdConnectProvider({
       wallet,
       updateWallet: setWallet,
       isModalOpen,
-      openModal: () => setIsModalOpen(true),
-      closeModal: () => setIsModalOpen(false),
+      openModal,
+      closeModal,
       format,
       updateFormat: setFormat,
       disconnectWallet,
     }),
     [
       address,
-      publicKey,
-      network,
-      wallet,
-      isModalOpen,
-      format,
-      disconnectWallet,
       setAddress,
+      publicKey,
       setPublicKey,
+      network,
       setNetwork,
+      wallet,
       setWallet,
+      isModalOpen,
+      openModal,
+      closeModal,
+      format,
       setFormat,
+      disconnectWallet,
     ],
   );
 

--- a/packages/ord-connect/src/providers/OrdContext.tsx
+++ b/packages/ord-connect/src/providers/OrdContext.tsx
@@ -99,7 +99,7 @@ export type OrdConnectProviderProps = {
  * }
  *
  * @param props - Props object.
- * @param props.initialNetwork - Initial network state if network is not set
+ * @param props.initialNetwork - Initial network state if network is not set.
  * @returns Provider component for OrdConnect.
  */
 export function OrdConnectProvider({

--- a/packages/ord-connect/src/providers/OrdContext.tsx
+++ b/packages/ord-connect/src/providers/OrdContext.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import { AddressFormat } from "@ordzaar/ordit-sdk";
 
+import { useLocalStorage } from "../hooks/useLocalStorage";
+
 export enum Network {
   MAINNET = "mainnet",
   TESTNET = "testnet",
@@ -67,37 +69,11 @@ const OrdContext = createContext<OrdContextType>({
   disconnectWallet: NOOP,
 });
 
-const KEY_PREFIX = "ord-connect";
 const ADDRESS = "address";
 const WALLET = "wallet";
 const PUBLIC_KEY = "publicKey";
 const FORMAT = "format";
 const NETWORK = "network";
-
-// Helper function to get item from localStorage
-function getItemFromLocalStorage<T>(_key: string): T | null {
-  const key = `${KEY_PREFIX}_${_key}`;
-  try {
-    return JSON.parse(localStorage.getItem(key)) as T | null;
-  } catch (error) {
-    console.error(`Error retrieving ${key} from localStorage`, error);
-    return null;
-  }
-}
-
-// Helper function to set item to localStorage
-function setItemToLocalStorage<T>(_key: string, value: T) {
-  const key = `${KEY_PREFIX}_${_key}`;
-  try {
-    if (value) {
-      localStorage.setItem(key, JSON.stringify(value));
-    } else {
-      localStorage.removeItem(key);
-    }
-  } catch (error) {
-    console.error(`Error saving ${key} to localStorage`, error);
-  }
-}
 
 export type OrdConnectProviderProps = {
   initialNetwork: Network;
@@ -123,30 +99,36 @@ export type OrdConnectProviderProps = {
  * }
  *
  * @param props - Props object.
- * @param props.initialNetwork - Initial network state.
+ * @param props.initialNetwork - Initial network state if network is not set
  * @returns Provider component for OrdConnect.
  */
 export function OrdConnectProvider({
   children,
   initialNetwork,
 }: PropsWithChildren<OrdConnectProviderProps>) {
-  const [address, setAddress] = useState<BiAddressString>(
-    () => getItemFromLocalStorage(ADDRESS) ?? EMPTY_BIADDRESS_OBJECT,
+  if (!initialNetwork) {
+    throw new Error("Initial network cannot be empty");
+  }
+
+  const [address, setAddress] = useLocalStorage<BiAddressString>(
+    ADDRESS,
+    EMPTY_BIADDRESS_OBJECT,
   );
 
-  const [network, setNetwork] = useState<Network>(
-    initialNetwork ?? getItemFromLocalStorage(NETWORK) ?? Network.TESTNET,
+  const [network, setNetwork] = useLocalStorage<Network>(
+    NETWORK,
+    initialNetwork,
   );
 
-  const [wallet, setWallet] = useState<Wallet | null>(() =>
-    getItemFromLocalStorage(WALLET),
-  );
-  const [publicKey, setPublicKey] = useState<BiAddressString>(
-    () => getItemFromLocalStorage(PUBLIC_KEY) ?? EMPTY_BIADDRESS_OBJECT,
+  const [wallet, setWallet] = useLocalStorage<Wallet | null>(WALLET, null);
+  const [publicKey, setPublicKey] = useLocalStorage<BiAddressString>(
+    PUBLIC_KEY,
+    EMPTY_BIADDRESS_OBJECT,
   );
 
-  const [format, setFormat] = useState<BiAddressFormat>(
-    () => getItemFromLocalStorage(FORMAT) ?? EMPTY_BIADDRESS_OBJECT,
+  const [format, setFormat] = useLocalStorage<BiAddressFormat>(
+    FORMAT,
+    EMPTY_BIADDRESS_OBJECT,
   );
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -156,38 +138,23 @@ export function OrdConnectProvider({
     setPublicKey(EMPTY_BIADDRESS_OBJECT);
     setFormat(EMPTY_BIADDRESS_OBJECT);
     setWallet(null);
-  }, []);
+  }, [setAddress, setFormat, setPublicKey, setWallet]);
 
   const context: OrdContextType = useMemo(
     () => ({
       address,
-      updateAddress: (newAddress) => {
-        setItemToLocalStorage(ADDRESS, newAddress);
-        setAddress(newAddress);
-      },
+      updateAddress: setAddress,
       publicKey,
-      updatePublicKey: (newPublicKey) => {
-        setItemToLocalStorage(PUBLIC_KEY, newPublicKey);
-        setPublicKey(newPublicKey);
-      },
+      updatePublicKey: setPublicKey,
       network,
-      updateNetwork: (newNetwork) => {
-        setItemToLocalStorage(NETWORK, newNetwork);
-        setNetwork(newNetwork);
-      },
+      updateNetwork: setNetwork,
       wallet,
-      updateWallet: (newWallet) => {
-        setItemToLocalStorage(WALLET, newWallet);
-        setWallet(newWallet);
-      },
+      updateWallet: setWallet,
       isModalOpen,
       openModal: () => setIsModalOpen(true),
       closeModal: () => setIsModalOpen(false),
       format,
-      updateFormat: (newFormat) => {
-        setItemToLocalStorage(FORMAT, newFormat);
-        setFormat(newFormat);
-      },
+      updateFormat: setFormat,
       disconnectWallet,
     }),
     [
@@ -198,6 +165,11 @@ export function OrdConnectProvider({
       isModalOpen,
       format,
       disconnectWallet,
+      setAddress,
+      setPublicKey,
+      setNetwork,
+      setWallet,
+      setFormat,
     ],
   );
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- When disconnecting a wallet, don't reconnect to the wallet on page refresh - it should forget the wallet
- Memoise openModal, closeModal since these references were unstable
- Remove unused rule since ord-connect isn't on nextjs

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
