### PR TITLE
fix(build): ensure external deps are not bundled

### DIFF
--- a/packages/ord-connect/vite.config.ts
+++ b/packages/ord-connect/vite.config.ts
@@ -10,15 +10,6 @@ import * as packageJson from "./package.json";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  optimizeDeps: {
-    esbuildOptions: {
-      // Node.js global to browser globalThis
-      define: {
-        global: "globalThis",
-      },
-    },
-    include: [...Object.keys(packageJson.peerDependencies)],
-  },
   build: {
     lib: {
       entry: {
@@ -27,10 +18,17 @@ export default defineConfig({
       formats: ["es"],
     },
     rollupOptions: {
-      external: [...Object.keys(packageJson.peerDependencies)],
+      external: [
+        ...Object.keys(packageJson.peerDependencies),
+        /^@ordzaar\/ordit-sdk\/.*/, // ordit-sdk/unisat, ordit-sdk/xverse imports
+      ],
     },
     commonjsOptions: {
-      include: [/node_modules/, ...Object.keys(packageJson.peerDependencies)],
+      include: [
+        /node_modules/,
+        ...Object.keys(packageJson.peerDependencies),
+        /^@ordzaar\/ordit-sdk\/.*/, // ordit-sdk/unisat, ordit-sdk/xverse imports
+      ],
     },
   },
   plugins: [
@@ -41,9 +39,9 @@ export default defineConfig({
     eslint(),
     cssInjectedByJsPlugin(),
     nodePolyfills({
-      // Whether to polyfill specific globals.
       globals: {
-        Buffer: true, // can also be 'build', 'dev', or false
+        // required for ordit-sdk functionality
+        Buffer: true,
       },
     }),
   ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Fixes `@ordzaar/ordit-sdk/unisat` and `@ordzaar/ordit-sdk/xverse` being bundled during build which throws a different instance of errors, causing `BrowserWalletNotInstalledError` to never visit the unisat/xverse website when the wallet provider is not installed

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
