### PR TITLE
fix(unisat): ensure address change listener is added

### DIFF
--- a/packages/ord-connect/src/components/SelectWalletModal/index.tsx
+++ b/packages/ord-connect/src/components/SelectWalletModal/index.tsx
@@ -172,12 +172,16 @@ export function SelectWalletModal({
 
   // Reconnect address change listener if there there is already a connected wallet
   useEffect(() => {
+    if (wallet !== Wallet.UNISAT) {
+      return undefined;
+    }
+
     let isMounted = true;
     let isConnectSuccessful = false;
     const listener = () => onConnectUnisatWallet();
 
-    if (wallet === Wallet.UNISAT && address && publicKey && format) {
-      const connectToUnisatWalletOnLoad = async () => {
+    if (address && publicKey && format) {
+      const connectToUnisatWalletOnReady = async () => {
         const isUnisatExtensionReady = await waitForUnisatExtensionReady();
         if (!isMounted) {
           return;
@@ -196,7 +200,7 @@ export function SelectWalletModal({
           window.unisat.addListener("accountsChanged", listener);
         }
       };
-      connectToUnisatWalletOnLoad();
+      connectToUnisatWalletOnReady();
     }
     return () => {
       isMounted = false;
@@ -204,7 +208,7 @@ export function SelectWalletModal({
         window.unisat.removeListener("accountsChanged", listener);
       }
     };
-  }, []);
+  }, [wallet, onConnectUnisatWallet, disconnectWallet]);
 
   return (
     <Transition appear show={isOpen} as={Fragment}>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- Fixes an issue where if the user doesn't connect to unisat on page load, and then connects to unisat and changes their unisat account, no listener is added and we won't be able to detect the address change. This fix also ensures that the listener is deleted if the wallet (unisat/xverse) is changed.

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
