### PR TITLE
feat(useBalance): update useBalance to getBalance instead of getUnspents

### DIFF
--- a/packages/ord-connect/package.json
+++ b/packages/ord-connect/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.18",
+    "bignumber.js": "^9.1.2",
     "bitcoinjs-lib": "6.1.5",
     "boring-avatars": "^1.10.1"
   },

--- a/packages/ord-connect/src/hooks/useBalance.tsx
+++ b/packages/ord-connect/src/hooks/useBalance.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import BigNumber from "bignumber.js";
 import {
   ADDRESS_FORMAT_TO_TYPE,
   AddressType,
@@ -32,7 +33,9 @@ export function useBalance() {
       const datasource = new JsonRpcDatasource({ network });
 
       const totalBalance = await datasource.getBalance({ address });
-      const totalAmountInSats = Math.round(totalBalance * 100_000_000);
+      const totalAmountInSats = Number(
+        new BigNumber(totalBalance).multipliedBy(100_000_000).toFixed(0, 5),
+      );
 
       setLoading(false);
       return totalAmountInSats;

--- a/packages/ord-connect/src/hooks/useBalance.tsx
+++ b/packages/ord-connect/src/hooks/useBalance.tsx
@@ -30,19 +30,12 @@ export function useBalance() {
       )[0];
 
       const datasource = new JsonRpcDatasource({ network });
-      const { spendableUTXOs } = await datasource.getUnspents({
-        address,
-        type: "spendable",
-      });
 
-      const totalSatsAvailable = spendableUTXOs.reduce(
-        (total: number, spendable: { safeToSpend: boolean; sats: number }) =>
-          spendable.safeToSpend ? total + spendable.sats : total,
-        0,
-      );
+      const totalBalance = await datasource.getBalance({ address });
+      const totalAmountInSats = Math.round(totalBalance * 100_000_000);
 
       setLoading(false);
-      return totalSatsAvailable;
+      return totalAmountInSats;
     } catch (err) {
       setError((err as Error).message);
       setLoading(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@ordzaar/ordit-sdk':
         specifier: 1.5.0
         version: 1.5.0
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       bitcoinjs-lib:
         specifier: 6.1.5
         version: 6.1.5


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR is to update the useBalance() hook to `getBalance` instead of `getUnspents`
Reason being `useSend` psbtBuilder will already check for spendable UTXOs 
setting useBalance to `getBalance` to check for wallet balance will allow faster balance checks when minting compared to `getUnspents`

always getting `getUnspents` especially for whale wallets will result in long wait time from the rpc

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] No console errors on web
- [ ] Your UI implementation visually matched the rendered design\*
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
